### PR TITLE
Mwallschlaeger multipipeline and async fork pipelines

### DIFF
--- a/bitflow/pipeline.py
+++ b/bitflow/pipeline.py
@@ -78,7 +78,8 @@ class Pipeline(threading.Thread):
 	# forward sample to ps after the given one
 	def execute_after(self,s,ps):
 		pos = self.get_processing_step_position(ps)
-		if pos == -1:
+		# do not forward after unknown ps or if there is no following ps
+		if pos == -1 or len(self.get_processing_steps()) <= pos + 1:
 			return
 		q = self.get_subqueue(pos + 1) # ps after the searched one
 		q.put(s)

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,18 +36,18 @@ python-bitflow -script "testing/testing_file_in.txt -> Noop()""
 #### Script example 2. reading file into PlotLinePlot processing step
 This will generate in .png file in the current path
 ```
-python-bitflow -script "testing/testing_file_in.txt -> PlotLinePlot(metric_names='ongoing_connections')"
+python-bitflow -script "testing/in.csv-> PlotLinePlot(metric_names='ongoing_connections')"
 ```
 
 #### Script example 3. reading file into PlotLinePlot processing step
 Reads testing file, if tag "filter" is set to "port_1935" the metric pkg_out_1300-1400 will be plottet, else if tag "filter" is set to "port_1936" the metric pkg_out_1400-1500. Afterwards both kind of samples got forwarded to a Noop() processing step.
 ```
-python-bitflow -script "testing/testing_file_in.txt -> Fork_Tags(tag='filter'){ port_1935 -> PlotLinePlot(metric_names='pkg_out_1300-1400') ; port_1936 -> PlotLinePlot(metric_names='pkg_out_1400-1500') } -> Noop()" 
+python-bitflow -script "testing/in.csv -> Fork_Tags(tag='filter'){ port_1935 -> PlotLinePlot(metric_names='pkg_out_1300-1400') ; port_1936 -> PlotLinePlot(metric_names='pkg_out_1400-1500') } -> Noop()"
 ```
 
 #### Script example 4. load processing step from external file (requires installation)
 ```
-python-bitflow -script "testing/testing_file_in.txt -> my_processing()" -p my_processing.py
+python-bitflow -script "testing/in.csv -> my_processing()" -p my_processing.py
 ```
 Current version does not close properly in all cases. Use strg-C to exit.
 
@@ -59,10 +59,7 @@ Current version does not close properly in all cases. Use strg-C to exit.
 **provide-data.py**: reads a file and provides this file via a listen port
 
 ## TODO
-* more testing testing
 * closing python-bitflow properly
 
 ## Known Issues:
-* not all implemented processing steps are prepared to run in bitflow scripts
-* sometimes a zombie process still exisits after closing python-bitflow with strg+c
 * Forks are currently not listed in -capabilities 

--- a/tests.py
+++ b/tests.py
@@ -376,6 +376,21 @@ class TestBitflowScriptParser(unittest.TestCase):
 
 class TestFork(unittest.TestCase):
 
+    def test_fork_in_bf_script_simple(self):
+         tp = parse_script("debuggenerationstep() -> Fork_Tags(tag=blub){* -> addtag(tags={a=b})")
+
+    def test_fork_in_bf_script_intermediate(self):
+         tp = parse_script(
+            "debuggenerationstep() -> Fork_Tags(tag=blub){\
+                                        bla -> addtag( tags={a=b} ) }\
+                                    -> Noop()")
+    def test_fork_in_bf_script_advanced(self):
+         tp = parse_script(
+            "debuggenerationstep() -> Fork_Tags(tag=blub){\
+                                        bla -> addtag(tags={a=b});\
+                                        blub -> addtag(tags={a=c})}\
+                                    -> Noop()")
+
     def test_pipeline_and_fork(self):
         fork = Fork_Tags(tag="blub")
         fork.add_processing_steps([],["bla","blub"])


### PR DESCRIPTION
multiple pipelines now get parsed in bitflow script
runtime changes in fork subpipelines:
after a sample traversed a fork subpipeline in now gets forwarded to the next step after the pipeline differently. this changes bound fork pipelines and normal pipelines to individual thread.